### PR TITLE
Remove unused imports and clean up code

### DIFF
--- a/lib/features/manage_audiances/ui/screens/contact_screen.dart
+++ b/lib/features/manage_audiances/ui/screens/contact_screen.dart
@@ -7,7 +7,6 @@ import 'package:bulk_app/features/manage_audiances/ui/widgets/contact_screen_wid
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_contacts/flutter_contacts.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 
 import '../../../../core/widgets/custom_app_bar.dart';

--- a/lib/features/whats_bots/ui/widgets/custom_expansion_tile.dart
+++ b/lib/features/whats_bots/ui/widgets/custom_expansion_tile.dart
@@ -25,12 +25,11 @@ class CustomExpansionTile extends StatefulWidget {
 class _CustomExpansionTileState extends State<CustomExpansionTile> {
   @override
   Widget build(BuildContext context) {
-    final cubit = context.read<WhatsbotsCubit>();
 
     return Theme(
       data: Theme.of(context).copyWith(
         dividerColor: Colors.transparent,
-      ), // Remove defa
+      ), 
       child: ExpansionTile(
         childrenPadding: EdgeInsets.zero,
         tilePadding: EdgeInsets.zero,


### PR DESCRIPTION
Removed the unused `flutter_contacts` import from `contact_screen.dart` and cleaned up the `custom_expansion_tile.dart` file by removing an unnecessary variable assignment and a trailing comment. This improves code readability and reduces clutter.